### PR TITLE
Support 500-error responses to API requests

### DIFF
--- a/lib/visualplatform.js
+++ b/lib/visualplatform.js
@@ -74,6 +74,8 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
               console.log('JSON parse error', e);
               return reject('Error parsing json');
             }
+          }).on('fail', function(message) {
+            return reject(message);
           }).on('error', function(err) {
             err = JSON.parse(err);
             return reject(err.message);


### PR DESCRIPTION
Without this patch, the promise-callbacks are never called when the server replies 500 to a method.