### PR TITLE
Added replace token endpoint and GET-requests for cached responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 23 Video API for Node.js
 
-`node-23video` is a full implementation of [The 23 Video API](http://www.23developer.com/api) (or more correctly, The Visualplatform API) for [Node.js](http://www.nodejs.org). 
+`node-23video` is a full implementation of [The 23 Video API](http://www.23developer.com/api) (or more correctly, The Visualplatform API) for [Node.js](http://www.nodejs.org).
 
 The library includes:
 
@@ -45,6 +45,10 @@ All methods requiring authentication takes `access_token` and `access_token_secr
 
 The library using [@kriszyp](https://twitter.com/kriszyp)'s [`node-promise`](https://github.com/kriszyp/node-promise) complete implementation of JavaScript promises.
 
+## Making use of cached responses
+
+If you add a `requestMethod` with value `GET'` to the request arguments, the module will use an anonymous `GET` request, to make use of caching and save resources on the api.
+Will be overruled if `include_unpublished_p` is true, since administritive permissions are necessary and can't be made with a `GET`-request.
 
 ## Exchanging tokens (or: Having user grant access to the API)
 
@@ -56,7 +60,7 @@ A few examples can illustrate how the methods are used. First, [the command-line
     visualplatform.beginAuthentication()
       .then(function(url){
             console.log('To verify access, open the following URL in your browser and follow the instructions.\n  '+url+'\n');
-            program.prompt('To complete the authorization, paste the string from the browser here: ', function(verifier){        
+            program.prompt('To complete the authorization, paste the string from the browser here: ', function(verifier){
                              process.stdin.destroy();
                              visualplatform.completeAuthentication(null, verifier)
                                .then(

--- a/lib/visualplatform.js
+++ b/lib/visualplatform.js
@@ -33,7 +33,6 @@ var oauth = require('./oauth');
 var url = require('url');
 var querystring = require('querystring');
 
-
 module.exports = Visualplatform = function(domain, key, secret, callback_url){
   var $ = this;
   var rest = require('restler');
@@ -46,14 +45,61 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
   $.call = function(method, data, access_token, access_secret){
     // Handle arguments
     return new Promise(function(fulfill, reject) {
-	    data = data||{};
-	    data['format'] = 'json';
-	    data['raw'] = '1';
-	    access_token = access_token||'';
-	    access_secret = access_secret||'';
-	    // Set up the request with callbacks
+      data = data||{};
+      data['format'] = 'json';
+      data['raw'] = '1';
+      access_token = access_token||'';
+      access_secret = access_secret||'';
+      console.log(data);
 
-	    rest.post('https://'+$.serviceDomain+method, {
+      var handleSuccess = function(res) {
+        // Use try/catch to avoid malformed JSON-responses
+        try {
+          res = JSON.parse(res);
+          // Status might not be ok, even though the request went through
+          if (!res.status == 'OK') return reject(res.message);
+          else {
+            return fulfill(res);
+          }
+        }
+        catch (e) {
+          console.log('JSON parse error', e);
+          return reject('Error parsing response');
+        }
+      }
+      var handleErr = function(res) {
+        // Use try/catch to avoid malformed JSON-responses
+        try {
+          res = JSON.parse(res);
+          // If response is object, parse and return err, if response is a number it's a timeout
+          if (typeof res == Object) {
+            return reject(res.message);
+          } else if (!isNaN(res)) {
+            return reject('Timeout: ' + res);
+          } else {
+            return reject(res);
+          }
+        }
+        catch(e) {
+          console.log('JSON parse error', e);
+          return reject('Error parsing response');
+        }
+      }
+
+      if (data.requestMethod == 'GET' && (!data.include_unpublished_p || data.include_unpublished_p == 0) && cached.indexOf(method) > -1) {
+        // Remove request method from data, since it has no effect on api calls
+        delete data.requestMethod;
+
+        // Set up the request with callbacks
+        rest.get(url.parse('https://'+$.serviceDomain+':443'+method+'?'+querystring.stringify(data)))
+          .on('success', handleSuccess)
+          .on('fail', handleErr)
+          .on('error', handleErr)
+          .on('timeout', handleErr);
+
+      } else {
+        // Set up the request with callbacks
+        rest.post('https://'+$.serviceDomain+method, {
             data:data,
             headers: {
               Authorization: oauth.signature(url.parse('https://'+$.serviceDomain+':443'+method+'?'+querystring.stringify(data)), {
@@ -64,29 +110,19 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
                 method: 'POST'
               })
             }
-          }).on('success', function(res) {
-            try {
-              res = JSON.parse(res);
-              if(!res.status == 'ok') return reject(res.message);
-              else return fulfill(res);
-            }
-            catch (e) {
-              console.log('JSON parse error', e);
-              return reject('Error parsing json');
-            }
-          }).on('fail', function(message) {
-            return reject(message);
-          }).on('error', function(err) {
-            err = JSON.parse(err);
-            return reject(err.message);
-          }).on('timeout', function(ms) {
-            return reject('Timeout: ' + ms);
-          });
+          })
+          .on('success', handleSuccess)
+          .on('fail', handleErr)
+          .on('error', handleErr)
+          .on('timeout', handleErr);
+      }
     });
   }
 
   // Map entire Visualplatform API
   var methods = ['/api/analytics/report/event', '/api/analytics/report/play', '/api/analytics/extract/play-details', '/api/analytics/extract/play-totals', '/api/album/create', '/api/album/delete', '/api/album/list', '/api/album/update', '/api/comment/add', '/api/comment/delete', '/api/comment/list', '/api/photo/coordinate/add', '/api/photo/coordinate/delete', '/api/distribution/ios/push-notification', '/api/distribution/ios/register-device', '/api/distribution/ios/unregister-device', '/api/license/list', '/api/live/create', '/api/live/delete', '/api/live/list', '/api/live/update', '/api/live/upload-image', '/api/live/start-recording', '/api/live/stop-recording', '/api/photo/delete', '/api/photo/frame', '/api/photo/get-upload-token', '/api/photo/get-replace-token', '/api/photo/list', '/api/photo/rate', '/api/photo/redeem-replace-token', '/api/photo/redeem-upload-token', '/api/photo/replace', '/api/photo/update', '/api/photo/update-upload-token', '/api/photo/upload', '/api/player/list', '/api/player/settings', '/api/photo/section/create', '/api/photo/section/delete', '/api/photo/section/list', '/api/photo/section/set-thumbnail', '/api/photo/section/update', '/api/session/get-token', '/api/session/redeem-token', '/api/site/get', '/api/photo/subtitle/list', '/api/tag/list', '/api/tag/related', '/api/echo', '/api/user/create', '/api/user/get-login-token', '/api/user/list', '/api/user/redeem-login-token'];
+  // Map cached endpoints for saving resources spent on api requests
+  var cached = ['/api/album/list','/api/comment/list/','/api/license/list','/api/live/list','/api/photo/frame','/api/photo/list','/api/player/list','/api/player/settings','/api/photo/section/list','/api/site/get','/api/photo/subtitle/list','/api/tag/list','/api/tags/related'];
 
   // Build functions for each Visualplatform API method
   for (i in methods) {
@@ -136,6 +172,7 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
   $.completeAuthentication = function(token, verifier){
     return $.oauth.access_token(token||$._oauthToken, verifier);
   }
+
 
   return(this);
 };

--- a/lib/visualplatform.js
+++ b/lib/visualplatform.js
@@ -50,7 +50,6 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
       data['raw'] = '1';
       access_token = access_token||'';
       access_secret = access_secret||'';
-      console.log(data);
 
       var handleSuccess = function(res) {
         // Use try/catch to avoid malformed JSON-responses

--- a/lib/visualplatform.js
+++ b/lib/visualplatform.js
@@ -19,10 +19,10 @@ Methods can be called as:
   visualplatform['photo.updateUploadToken'](...)
   visualplatform['/api/photo/update-upload-token'](...)
 
-The first parameter is always a JS object with the filter data  described in 
+The first parameter is always a JS object with the filter data  described in
 http://www.23developer.com/api/#methods
 
-All methods requiring authentication takes access_token and access_secret 
+All methods requiring authentication takes access_token and access_secret
 as their second and third parameters.
 
 */
@@ -41,7 +41,7 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
   $.consumer_key = key;
   $.consumer_secret = secret;
   $.callback_url = callback_url||'';
-  
+
   /* API WEB SERVICE API */
   $.call = function(method, data, access_token, access_secret){
     // Handle arguments
@@ -64,7 +64,7 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
                 method: 'POST'
               })
             }
-          }).on('success', function(res) {            
+          }).on('success', function(res) {
             try {
               res = JSON.parse(res);
               if(!res.status == 'ok') return reject(res.message);
@@ -84,9 +84,9 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
           });
     });
   }
-  
+
   // Map entire Visualplatform API
-  var methods = ['/api/analytics/report/event', '/api/analytics/report/play', '/api/analytics/extract/play-details', '/api/analytics/extract/play-totals', '/api/album/create', '/api/album/delete', '/api/album/list', '/api/album/update', '/api/comment/add', '/api/comment/delete', '/api/comment/list', '/api/photo/coordinate/add', '/api/photo/coordinate/delete', '/api/distribution/ios/push-notification', '/api/distribution/ios/register-device', '/api/distribution/ios/unregister-device', '/api/license/list', '/api/live/create', '/api/live/delete', '/api/live/list', '/api/live/update', '/api/live/upload-image', '/api/live/start-recording', '/api/live/stop-recording', '/api/photo/delete', '/api/photo/frame', '/api/photo/get-upload-token', '/api/photo/list', '/api/photo/rate', '/api/photo/redeem-upload-token', '/api/photo/replace', '/api/photo/update', '/api/photo/update-upload-token', '/api/photo/upload', '/api/player/list', '/api/player/settings', '/api/photo/section/create', '/api/photo/section/delete', '/api/photo/section/list', '/api/photo/section/set-thumbnail', '/api/photo/section/update', '/api/session/get-token', '/api/session/redeem-token', '/api/site/get', '/api/photo/subtitle/list', '/api/tag/list', '/api/tag/related', '/api/echo', '/api/user/create', '/api/user/get-login-token', '/api/user/list', '/api/user/redeem-login-token'];
+  var methods = ['/api/analytics/report/event', '/api/analytics/report/play', '/api/analytics/extract/play-details', '/api/analytics/extract/play-totals', '/api/album/create', '/api/album/delete', '/api/album/list', '/api/album/update', '/api/comment/add', '/api/comment/delete', '/api/comment/list', '/api/photo/coordinate/add', '/api/photo/coordinate/delete', '/api/distribution/ios/push-notification', '/api/distribution/ios/register-device', '/api/distribution/ios/unregister-device', '/api/license/list', '/api/live/create', '/api/live/delete', '/api/live/list', '/api/live/update', '/api/live/upload-image', '/api/live/start-recording', '/api/live/stop-recording', '/api/photo/delete', '/api/photo/frame', '/api/photo/get-upload-token', '/api/photo/get-replace-token', '/api/photo/list', '/api/photo/rate', '/api/photo/redeem-replace-token', '/api/photo/redeem-upload-token', '/api/photo/replace', '/api/photo/update', '/api/photo/update-upload-token', '/api/photo/upload', '/api/player/list', '/api/player/settings', '/api/photo/section/create', '/api/photo/section/delete', '/api/photo/section/list', '/api/photo/section/set-thumbnail', '/api/photo/section/update', '/api/session/get-token', '/api/session/redeem-token', '/api/site/get', '/api/photo/subtitle/list', '/api/tag/list', '/api/tag/related', '/api/echo', '/api/user/create', '/api/user/get-login-token', '/api/user/list', '/api/user/redeem-login-token'];
 
   // Build functions for each Visualplatform API method
   for (i in methods) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-23video",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "node-23video is a full implementation of The 23 Video API (or more correctly, The Visualplatform API) for Node.js.",
   "main": "lib/visualplatform.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-23video",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "node-23video is a full implementation of The 23 Video API (or more correctly, The Visualplatform API) for Node.js.",
   "main": "lib/visualplatform.js",
   "scripts": {
@@ -22,7 +22,8 @@
   ],
   "author": "Steffen T. Christensen",
   "contributors": [
-    "Peter Dremstrup <peter@dremstrup.dk> (http://peterdremstrup.dk)"
+    "Peter Dremstrup <peter@dremstrup.dk> (http://peterdremstrup.dk)",
+    "Håkon Nessjøen <haakon.nessjoen@gmail.com (http://lunatic.no/)"
   ],
   "bugs": {
     "url": "https://github.com/23/node-23video/issues"


### PR DESCRIPTION
I've updated the code to include some extra endpoints (should probably include the rest at some point), and a possibility to use GET-requests to save api load via the property `requestMethod` in the argument object.

We should probably also include some tests at some point.
